### PR TITLE
Add CopyAll* commands for copying multiple buffer paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+copy-file-path.nvimは、Neovimでファイルパスをクリップボードにコピーするためのプラグインです。単体ファイルのパスコピーと、開いている全バッファのパス一括コピーの両方をサポートします。
+
+## アーキテクチャ
+
+### メインファイル: `plugin/copy-file-path.lua`
+
+**コア関数:**
+- `format_path(mods, buf_path)`: filename-modifiersを使用したパスフォーマット。第2引数省略時は現在のバッファ
+- `copy_to_clipboard(path)`: クリップボードへのコピーとユーザーフィードバック
+- `get_all_buffer_paths(mods)`: 全バッファのパスを指定形式で取得
+- `copy_all_buffer_paths(mods, opts)`: 全バッファパスの区切り文字処理とコピー
+- `parse_separator(separator)`: エスケープ文字（"\n", "\t"）の変換
+
+**コマンド体系:**
+- 単体ファイル用: `CopyRelativeFilePath`, `CopyAbsoluteFilePath`, `CopyRelativeFilePathFromHome`, `CopyFileName`
+- 全バッファ用: `CopyAllRelativeFilePaths [separator]`, `CopyAllAbsoluteFilePaths [separator]`, `CopyAllRelativeFilePathsFromHome [separator]`, `CopyAllFileNames [separator]`
+- すべて`vim.api.nvim_create_user_command`で統一実装
+
+**filename-modifiers:**
+- `:p` - 絶対パス
+- `:.` - 相対パス  
+- `:~` - ホームディレクトリからの相対パス
+- `:t` - ファイル名のみ
+
+## 開発コマンド
+
+コードフォーマット:
+```bash
+stylua .
+```
+
+## コーディング規約
+
+- styluaによるLuaコードフォーマット設定: 2スペースインデント、ダブルクォート使用
+- 関数には適切な型注釈（`---@param`, `---@return`）を記述
+- `vim.api.nvim_create_user_command`でコマンド定義を統一
+- 共通処理は関数に抽出して重複を避ける
+- エラーハンドリング: バッファが存在しない場合の適切なメッセージ表示

--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ Simply install copy-file-path.nvim with your favourite plugin manager (e.g. vim-
 |`:CopyRelativeFilePathFromHome`|Copy relative file path from `$HOME` to the clipboard.|
 |`:CopyFileName`|Copy just the file name to the clipboard.|
 |`:CopyFilePath`|Alias for `CopyRelativeFilePath`|
+|`:CopyAllRelativeFilePaths [separator]`|Copy all relative file paths to the clipboard. Default separator is space.|
+|`:CopyAllAbsoluteFilePaths [separator]`|Copy all absolute file paths to the clipboard. Default separator is space.|
+|`:CopyAllRelativeFilePathsFromHome [separator]`|Copy all relative file paths from `$HOME` to the clipboard. Default separator is space.|
+|`:CopyAllFileNames [separator]`|Copy all file names to the clipboard. Default separator is space.|
+
+For the `CopyAll*` commands, you can specify a separator:
+- `,` for comma separation
+- `"\n"` for newline separation
+- `"\t"` for tab separation
+- Any other string as a custom separator

--- a/plugin/copy-file-path.lua
+++ b/plugin/copy-file-path.lua
@@ -1,8 +1,10 @@
 ---@param mods string filename-modifiers
+---@param buf_path string|nil file path (defaults to current buffer)
 ---@return string
 ---see: https://vim-jp.org/vimdoc-ja/cmdline.html#filename-modifiers
-local function get_path(mods)
-  return vim.fn.fnamemodify(vim.fn.expand("%"), mods)
+local function format_path(mods, buf_path)
+  local path = buf_path or vim.fn.expand("%")
+  return vim.fn.fnamemodify(path, mods)
 end
 
 ---@param path string
@@ -11,20 +13,78 @@ local function copy_to_clipboard(path)
   vim.api.nvim_echo({ { "Copied: " .. path } }, false, {})
 end
 
+---@param separator string
+---@return string
+local function parse_separator(separator)
+  if separator == "\\n" then
+    return "\n"
+  elseif separator == "\\t" then
+    return "\t"
+  else
+    return separator
+  end
+end
+
+---@param mods string filename-modifiers
+---@return string[]
+local function get_all_buffer_paths(mods)
+  local paths = {}
+  local buffers = vim.api.nvim_list_bufs()
+
+  for _, buf in ipairs(buffers) do
+    if vim.api.nvim_buf_is_loaded(buf) and vim.api.nvim_buf_get_name(buf) ~= "" then
+      local path = format_path(mods, vim.api.nvim_buf_get_name(buf))
+      table.insert(paths, path)
+    end
+  end
+
+  return paths
+end
+
+---@param mods string filename-modifiers
+local function copy_all_buffer_paths(mods, opts)
+  local separator = opts.args and opts.args ~= "" and parse_separator(opts.args) or " "
+  local paths = get_all_buffer_paths(mods)
+
+  if #paths == 0 then
+    vim.api.nvim_echo({ { "No buffers with file paths found" } }, false, {})
+    return
+  end
+
+  local result = table.concat(paths, separator)
+  copy_to_clipboard(result)
+end
+
 vim.api.nvim_create_user_command("CopyRelativeFilePath", function()
-  copy_to_clipboard(get_path(":."))
+  copy_to_clipboard(format_path(":."))
 end, { nargs = 0, force = true, desc = "Copy relative file path to the clipboard" })
 
 vim.api.nvim_create_user_command("CopyAbsoluteFilePath", function()
-  copy_to_clipboard(get_path(":p"))
+  copy_to_clipboard(format_path(":p"))
 end, { nargs = 0, force = true, desc = "Copy absolute file path to the clipboard" })
 
 vim.api.nvim_create_user_command("CopyRelativeFilePathFromHome", function()
-  copy_to_clipboard(get_path(":~"))
+  copy_to_clipboard(format_path(":~"))
 end, { nargs = 0, force = true, desc = "Copy relative file path from $HOME to the clipboard" })
 
 vim.api.nvim_create_user_command("CopyFileName", function()
-  copy_to_clipboard(get_path(":t"))
+  copy_to_clipboard(format_path(":t"))
 end, { nargs = 0, force = true, desc = "Copy just the file name to the clipboard" })
+
+vim.api.nvim_create_user_command("CopyAllRelativeFilePaths", function(opts)
+  copy_all_buffer_paths(":.", opts)
+end, { nargs = "?", force = true, desc = "Copy all relative file paths to the clipboard" })
+
+vim.api.nvim_create_user_command("CopyAllAbsoluteFilePaths", function(opts)
+  copy_all_buffer_paths(":p", opts)
+end, { nargs = "?", force = true, desc = "Copy all absolute file paths to the clipboard" })
+
+vim.api.nvim_create_user_command("CopyAllRelativeFilePathsFromHome", function(opts)
+  copy_all_buffer_paths(":~", opts)
+end, { nargs = "?", force = true, desc = "Copy all relative file paths from $HOME to the clipboard" })
+
+vim.api.nvim_create_user_command("CopyAllFileNames", function(opts)
+  copy_all_buffer_paths(":t", opts)
+end, { nargs = "?", force = true, desc = "Copy all file names to the clipboard" })
 
 vim.cmd("command! CopyFilePath CopyRelativeFilePath")


### PR DESCRIPTION
## Summary
- Add new commands to copy all buffer paths at once
- Implement 4 new commands: `CopyAllRelativeFilePaths`, `CopyAllAbsoluteFilePaths`, `CopyAllRelativeFilePathsFromHome`, `CopyAllFileNames`
- Support customizable separators (space, comma, newline, tab, or any custom string)

## New Commands
- `:CopyAllRelativeFilePaths [separator]` - Copy relative paths of all open buffers
- `:CopyAllAbsoluteFilePaths [separator]` - Copy absolute paths of all open buffers  
- `:CopyAllRelativeFilePathsFromHome [separator]` - Copy paths relative to $HOME
- `:CopyAllFileNames [separator]` - Copy just the filenames of all open buffers

## Usage Examples
```vim
:CopyAllRelativeFilePaths          " Space-separated (default)
:CopyAllRelativeFilePaths ,        " Comma-separated
:CopyAllRelativeFilePaths "\n"     " Newline-separated
:CopyAllAbsoluteFilePaths "\t"     " Tab-separated
```

🤖 Generated with [Claude Code](https://claude.ai/code)