### PR TITLE
Add line number support to single-file copy commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ copy-file-path.nvimは、Neovimでファイルパスをクリップボードに�
 **コア関数:**
 - `format_path(mods, buf_path)`: filename-modifiersを使用したパスフォーマット。第2引数省略時は現在のバッファ
 - `copy_to_clipboard(path)`: クリップボードへのコピーとユーザーフィードバック
+- `copy_current_buffer_path(mods, opts)`: 現在バッファのパスコピー。range指定時は行番号(`:42`, `:10-20`)を付与
 - `get_all_buffer_paths(mods)`: 全バッファのパスを指定形式で取得
 - `copy_all_buffer_paths(mods, opts)`: 全バッファパスの区切り文字処理とコピー
 - `parse_separator(separator)`: エスケープ文字（"\n", "\t"）の変換

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Simply install copy-file-path.nvim with your favourite plugin manager (e.g. vim-
 |`:CopyAllRelativeFilePathsFromHome [separator]`|Copy all relative file paths from `$HOME` to the clipboard. Default separator is space.|
 |`:CopyAllFileNames [separator]`|Copy all file names to the clipboard. Default separator is space.|
 
+The single-file commands (`CopyRelativeFilePath`, `CopyAbsoluteFilePath`, `CopyRelativeFilePathFromHome`, `CopyFileName` and `CopyFilePath`) accept a range, which appends line numbers to the copied path:
+
+- Select lines in visual mode and run `:'<,'>CopyRelativeFilePath` → `path/to/file.lua:10-20`
+- Run with a line number like `:42CopyRelativeFilePath` → `path/to/file.lua:42`
+
 For the `CopyAll*` commands, you can specify a separator:
 - `,` for comma separation
 - `"\n"` for newline separation

--- a/plugin/copy-file-path.lua
+++ b/plugin/copy-file-path.lua
@@ -26,6 +26,22 @@ local function parse_separator(separator)
 end
 
 ---@param mods string filename-modifiers
+---@param opts table command options
+local function copy_current_buffer_path(mods, opts)
+  local path = format_path(mods)
+
+  if opts.range > 0 then
+    if opts.line1 == opts.line2 then
+      path = path .. ":" .. opts.line1
+    else
+      path = path .. ":" .. opts.line1 .. "-" .. opts.line2
+    end
+  end
+
+  copy_to_clipboard(path)
+end
+
+---@param mods string filename-modifiers
 ---@return string[]
 local function get_all_buffer_paths(mods)
   local paths = {}
@@ -55,21 +71,21 @@ local function copy_all_buffer_paths(mods, opts)
   copy_to_clipboard(result)
 end
 
-vim.api.nvim_create_user_command("CopyRelativeFilePath", function()
-  copy_to_clipboard(format_path(":."))
-end, { nargs = 0, force = true, desc = "Copy relative file path to the clipboard" })
+vim.api.nvim_create_user_command("CopyRelativeFilePath", function(opts)
+  copy_current_buffer_path(":.", opts)
+end, { nargs = 0, range = true, force = true, desc = "Copy relative file path to the clipboard" })
 
-vim.api.nvim_create_user_command("CopyAbsoluteFilePath", function()
-  copy_to_clipboard(format_path(":p"))
-end, { nargs = 0, force = true, desc = "Copy absolute file path to the clipboard" })
+vim.api.nvim_create_user_command("CopyAbsoluteFilePath", function(opts)
+  copy_current_buffer_path(":p", opts)
+end, { nargs = 0, range = true, force = true, desc = "Copy absolute file path to the clipboard" })
 
-vim.api.nvim_create_user_command("CopyRelativeFilePathFromHome", function()
-  copy_to_clipboard(format_path(":~"))
-end, { nargs = 0, force = true, desc = "Copy relative file path from $HOME to the clipboard" })
+vim.api.nvim_create_user_command("CopyRelativeFilePathFromHome", function(opts)
+  copy_current_buffer_path(":~", opts)
+end, { nargs = 0, range = true, force = true, desc = "Copy relative file path from $HOME to the clipboard" })
 
-vim.api.nvim_create_user_command("CopyFileName", function()
-  copy_to_clipboard(format_path(":t"))
-end, { nargs = 0, force = true, desc = "Copy just the file name to the clipboard" })
+vim.api.nvim_create_user_command("CopyFileName", function(opts)
+  copy_current_buffer_path(":t", opts)
+end, { nargs = 0, range = true, force = true, desc = "Copy just the file name to the clipboard" })
 
 vim.api.nvim_create_user_command("CopyAllRelativeFilePaths", function(opts)
   copy_all_buffer_paths(":.", opts)
@@ -87,4 +103,6 @@ vim.api.nvim_create_user_command("CopyAllFileNames", function(opts)
   copy_all_buffer_paths(":t", opts)
 end, { nargs = "?", force = true, desc = "Copy all file names to the clipboard" })
 
-vim.cmd("command! CopyFilePath CopyRelativeFilePath")
+vim.api.nvim_create_user_command("CopyFilePath", function(opts)
+  copy_current_buffer_path(":.", opts)
+end, { nargs = 0, range = true, force = true, desc = "Alias for CopyRelativeFilePath" })


### PR DESCRIPTION
## Summary

Single-file commands (`CopyRelativeFilePath`, `CopyAbsoluteFilePath`, `CopyRelativeFilePathFromHome`, `CopyFileName`, `CopyFilePath`) now accept a range, which appends line numbers to the copied path:

- Visual selection + `:'<,'>CopyRelativeFilePath` → `path/to/file.lua:10-20`
- `:42CopyRelativeFilePath` → `path/to/file.lua:42`

Running without a range behaves exactly as before, so this is fully backward compatible.

The `CopyFilePath` alias was previously defined via `:command!` which cannot forward ranges, so it is now defined with `nvim_create_user_command` like the other commands.

## Verification

Tested with headless Neovim (`nvim --headless --clean --cmd "set rtp+=."`):

| Command | Result |
|:--|:--|
| `:CopyRelativeFilePath` | `README.md` (unchanged) |
| `:5,10CopyRelativeFilePath` | `README.md:5-10` |
| `:5CopyRelativeFilePath` | `README.md:5` |
| `:5,10CopyFilePath` | `README.md:5-10` |
| `:3,7CopyFileName` | `README.md:3-7` |
| `:CopyAllRelativeFilePaths ,` | `README.md,LICENSE` (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)