### PR TITLE
Use vim.notify for user feedback

### DIFF
--- a/plugin/copy-file-path.lua
+++ b/plugin/copy-file-path.lua
@@ -10,7 +10,7 @@ end
 ---@param path string
 local function copy_to_clipboard(path)
   vim.fn.setreg("+", path)
-  vim.api.nvim_echo({ { "Copied: " .. path } }, false, {})
+  vim.notify("Copied: " .. path, vim.log.levels.INFO)
 end
 
 ---@param separator string
@@ -47,7 +47,7 @@ local function copy_all_buffer_paths(mods, opts)
   local paths = get_all_buffer_paths(mods)
 
   if #paths == 0 then
-    vim.api.nvim_echo({ { "No buffers with file paths found" } }, false, {})
+    vim.notify("No buffers with file paths found", vim.log.levels.WARN)
     return
   end
 


### PR DESCRIPTION
## Summary

Replace `nvim_echo` with `vim.notify` for user feedback:

- `Copied: <path>` → `vim.log.levels.INFO`
- `No buffers with file paths found` → `vim.log.levels.WARN`

This lets notification UI plugins (e.g. nvim-notify, noice.nvim) pick up the messages, since they override `vim.notify`. The default `vim.notify` implementation just echoes the message, so the behavior is unchanged for users without such plugins.

## Verification

Tested with headless Neovim (`nvim --headless --clean --cmd "set rtp+=."`): both the `Copied: ...` and `No buffers with file paths found` messages are displayed as before, and the `+` register is set correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)